### PR TITLE
fix logout/faucet/mint on front

### DIFF
--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -69,6 +69,10 @@ const Nav = styled.nav``;
 const Menu = styled(Icon)`
   font-size: 15px;
   font-weight: 600;
+
+  :hover {
+    cursor: pointer;
+  }
 `;
 
 const SearchBar = styled.input`
@@ -120,6 +124,7 @@ function Header({isLoggedIn, setIsLoggedIn, user, setUser, address, setAddress})
       .post('http://localhost:5500/user/faucet', null, {withCredentials: true})
       .then(response => {
         console.log(response.data); // Do something with the response
+        alert(`ETH 받기 성공 ! 보유 ETH: ${response.data.data}`);
       })
       .catch(error => {
         console.error(error);
@@ -132,6 +137,16 @@ function Header({isLoggedIn, setIsLoggedIn, user, setUser, address, setAddress})
     setIsLoggedIn(localStorage.getItem('isLoggedIn'));
     setUser(localStorage.getItem('user'));
     setAddress(localStorage.getItem('address'));
+
+    // DB의 세션에서 user 정보 삭제
+    axios
+      .get('http://localhost:5500/logout', {withCredentials: true})
+      .then(res => {
+        console.log(res);
+      })
+      .catch(error => {
+        console.log(error);
+      });
   };
 
   return (
@@ -160,16 +175,15 @@ function Header({isLoggedIn, setIsLoggedIn, user, setUser, address, setAddress})
             </SearchBox>
           </Search>
           <Nav>
-            <Link to="/market">
-              <Menu>Market</Menu>
+            <Link to="/mint">
+              <Menu>Mint NFT</Menu>
             </Link>
 
             <Link to="/write">
               <Menu>Write</Menu>
             </Link>
-            <Link to="/write">
-              <Menu onClick={() => postFaucet()}>ETH Faucet</Menu>
-            </Link>
+
+            <Menu onClick={() => postFaucet()}>ETH Faucet</Menu>
           </Nav>
         </Column>
         {isLoggedIn ? (

--- a/server/controllers/main.controller.js
+++ b/server/controllers/main.controller.js
@@ -14,6 +14,7 @@ exports.main_get = async (req, res, next) => {
   }
 };
 
+// 더미 데이터 user 데이터 10개, post 데이터 200개를 생성하는 컨트롤러
 exports.dummy_get = async (req, res, next) => {
   try {
     // 1. User 더미 데이터 10개 만들고 넣기
@@ -40,4 +41,11 @@ exports.dummy_get = async (req, res, next) => {
   } catch (e) {
     Error(e);
   }
+};
+
+exports.logout_get = async (req, res, next) => {
+  req.session.user = null;
+  req.session.loggedIn = false;
+
+  return res.status(200).redirect('/hi');
 };

--- a/server/routes/main.route.js
+++ b/server/routes/main.route.js
@@ -5,5 +5,6 @@ const controller = require('../controllers/main.controller');
 
 router.get('/', controller.main_get);
 router.get('/dummy', controller.dummy_get);
+router.get('/logout', controller.logout_get);
 
 module.exports = router;


### PR DESCRIPTION
프론트

- 로그아웃 버튼 클릭시 : DB의 sessions에서 해당 user에 대한 데이터를 삭제

- ETH Faucet 클릭시 : 프론트에서 url 이동없이, 백엔드로 요청을 보내, 서버가  사용자 주소로 eth를 보내고, alert기능으로 잔액 알림
- mint : 헤더의 market > mint NFT로 수정하고, url 이동 또한 /market > /mint로 수정
